### PR TITLE
Update flutter_hls_video_player_controller.dart

### DIFF
--- a/lib/flutter_hls_video_player/controller/flutter_hls_video_player_controller.dart
+++ b/lib/flutter_hls_video_player/controller/flutter_hls_video_player_controller.dart
@@ -115,7 +115,8 @@ class FlutterHLSVideoPlayerController {
 
   Future<void> loadHlsVideo(String m3u8Url) async {
     try {
-      if (m3u8Url == 'null' || m3u8Url.split(".").last != "m3u8") {
+
+      if (m3u8Url == 'null' || !m3u8Url.contains('.m3u8')) {
         onError(message: "Failed to load video");
         return;
       }


### PR DESCRIPTION
https://github.com/dheeraj11qk/flutter_hls_video_player/blob/2ec81188ef713398604197a7a3b4565775208cc8/lib/flutter_hls_video_player/controller/flutter_hls_video_player_controller.dart#L118



The above line have an issue for example the URL contain a parameter that include the token and the expire which many exclusive content platform will need to include because they don't want they are able to be valid forever and they don't want unauthorized user to play it, following is an example of such URL:
https://vz-c1479451-d73.b-cdn.net/f8f08748-48d4-4de6-a576-59b5a4249c55/playlist.m3u8?token=tjVcaohFKFGOvT2FGwrKnlNX4_sNdR7XW1vDTkIKH10&expires=1752360298


we instead need to check if the last part contains the word  "m3u8"  rather than the current equality operation



Is it requires any more adjustment environ meaning code of the project please let me know, thank you.